### PR TITLE
JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.0</version>
           <configuration>
             <encoding>UTF-8</encoding>
           </configuration>
@@ -156,17 +156,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -177,26 +177,29 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.22.1</version>
           <configuration>
-            <forkCount>2C</forkCount>
-            <reuseForks>true</reuseForks>
-            <runOrder>alphabetical</runOrder>
-            <argLine>-XX:MaxPermSize=256m</argLine>
             <includes>
               <include>**/*Test.java</include>
               <include>**/*TestSuite.java</include>
             </includes>
+            <properties>
+              <configurationParameters>
+                junit.jupiter.execution.parallel.enabled=false
+                junit.jupiter.execution.parallel.config.strategy=dynamic
+                junit.jupiter.execution.parallel.config.dynamic.factor=1
+              </configurationParameters>
+            </properties>
             <systemPropertyVariables>
               <user.timezone>Europe/Paris</user.timezone>
               <user.language>fr</user.language>
@@ -207,12 +210,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -222,29 +225,29 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.7</version>
+          <version>3.7.1</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-ssh</artifactId>
-              <version>3.0.0</version>
+              <version>3.2.0</version>
             </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.0.1</version>
           <configuration>
             <quiet>true</quiet>
             <failOnError>false</failOnError>
@@ -272,7 +275,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>2.9</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -311,7 +314,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>2.2.4</version>
+          <version>2.2.5</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -445,8 +448,6 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
-                  <forkCount>1</forkCount>
-                  <reuseForks>false</reuseForks>
                   <includes>
                     <include>**/*IT.java</include>
                     <include>**/*ITSuite.java</include>


### PR DESCRIPTION
Upgrade the version of the Surefire and Failsafe Maven plugins to be able to run JUnit 5 tests.
Refine by the same time the configuration of both the plugins in order to run correctly the JUnit 5 unit tests (they ran badly in a parallel way).
Upgrade also the version of other plugins.

Don't forget to merge before the PR https://github.com/Silverpeas/silverpeas-test-dependencies-bom/pull/1
And to merge after this one the following PRs:
https://github.com/Silverpeas/Silverpeas-Core/pull/942
https://github.com/Silverpeas/Silverpeas-Components/pull/621