### PR TITLE
Feature #12259

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
                   <goal>verify</goal>
                 </goals>
                 <configuration>
+                  <skipAfterFailureCount>1</skipAfterFailureCount>
                   <includes>
                     <include>**/*IT.java</include>
                     <include>**/*ITSuite.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <packaging>pom</packaging>
   <artifactId>silverpeas-project</artifactId>
   <groupId>org.silverpeas</groupId>
-  <version>1.5-improve-it</version>
+  <version>1.5-SNAPSHOT</version>
   <name>Parent POM</name>
   <description>
     Silverpeas is an open-source project to build and run a Collaborative and Social Web Portal
@@ -124,10 +124,10 @@
   <properties>
     <!-- property used by the CI to both deploy a build version and release the next stable version -->
     <next.release>1.5</next.release>
-    <silverpeas.bom.version>1.5-improve-it</silverpeas.bom.version>
+    <silverpeas.bom.version>1.5-SNAPSHOT</silverpeas.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <wagon.version>3.3.3</wagon.version>
-    <wildfly.version>20.0.1.Final</wildfly.version>
+    <wildfly.version>23.0.1.Final</wildfly.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netbeans.hint.license>agpl30</netbeans.hint.license>
@@ -471,11 +471,6 @@
                   <environmentVariables>
                     <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
                   </environmentVariables>
-                  <!--
-                  <systemPropertyVariables>
-                    <arquillian.launch>wildfly-managed</arquillian.launch>
-                  </systemPropertyVariables>
-                  -->
                   <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <packaging>pom</packaging>
   <artifactId>silverpeas-project</artifactId>
   <groupId>org.silverpeas</groupId>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.5-improve-it</version>
   <name>Parent POM</name>
   <description>
     Silverpeas is an open-source project to build and run a Collaborative and Social Web Portal
@@ -124,7 +124,7 @@
   <properties>
     <!-- property used by the CI to both deploy a build version and release the next stable version -->
     <next.release>1.5</next.release>
-    <silverpeas.bom.version>1.5-SNAPSHOT</silverpeas.bom.version>
+    <silverpeas.bom.version>1.5-improve-it</silverpeas.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
     <wagon.version>3.3.3</wagon.version>
     <wildfly.version>20.0.1.Final</wildfly.version>

--- a/pom.xml
+++ b/pom.xml
@@ -470,9 +470,11 @@
                   <environmentVariables>
                     <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
                   </environmentVariables>
+                  <!--
                   <systemPropertyVariables>
                     <arquillian.launch>wildfly-managed</arquillian.launch>
                   </systemPropertyVariables>
+                  -->
                   <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>
               </execution>
@@ -494,7 +496,7 @@
       <dependencies>
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
-          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
Refactor the way the integration tests are running: instead of starting a Wildfly instance for each test class, it is started before the execution of the whole integration tests of the project. So, Wildfly is set as a remote container for Arquillian.
This requires to set up differently Wildfly. Currently, Wildfly 23.0.0 has been prepared for that and a Docker image dedicated to such builds has been pushed into the hub: silverpeas/silverbuild:6.3-it.