### PR TITLE
Feature #12866

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <next.release>1.6</next.release>
     <silverpeas.bom.version>1.6-SNAPSHOT</silverpeas.bom.version>
     <maven.compiler.release>11</maven.compiler.release>
-    <wagon.version>3.5.2</wagon.version>
+    <wagon.version>3.5.3</wagon.version>
     <wildfly.version>26.1.2.Final</wildfly.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -168,7 +168,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -287,7 +287,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -321,7 +321,7 @@
         <plugin>
           <groupId>org.wildfly.plugins</groupId>
           <artifactId>wildfly-maven-plugin</artifactId>
-          <version>3.0.2.Final</version>
+          <version>4.0.0.Final</version>
         </plugin>
         <plugin>
           <groupId>pl.project13.maven</groupId>


### PR DESCRIPTION
In the replacement of Jackrabbit by Oak, the access to the JCR repository is now done by a lib instead of a JCA. So dependencies requires to be managed differently.

The following PRs require to be merged along with this one:
- https://github.com/Silverpeas/silverpeas-test-dependencies-bom/pull/10
- https://github.com/Silverpeas/silverpeas-dependencies-bom/pull/47

The following PRs require to be integrated afeter this one:
- https://github.com/Silverpeas/Silverpeas-Core/pull/1255
- https://github.com/Silverpeas/Silverpeas-Components/pull/809
- https://github.com/Silverpeas/Silverpeas-Assembly/pull/24